### PR TITLE
Update SR60.md

### DIFF
--- a/Surveillance Report Sources/SR60.md
+++ b/Surveillance Report Sources/SR60.md
@@ -22,7 +22,7 @@ https://portswigger.net/daily-swig/google-mozilla-close-to-finalizing-sanitizer-
 
 https://www.theverge.com/2021/10/14/22725894/facebook-augmented-reality-ar-glasses-ai-systems-ego4d-research
 
-https://www.zdnet.com/article/facebook-partners-with-coinbase-for-digital-wallet-initiative/ 
+https://www.zdnet.com/article/facebook-partners-with-coinbase-for-digital-wallet-initiative/
 
 # Research
 
@@ -32,11 +32,11 @@ https://www.bleepingcomputer.com/news/security/credit-card-pins-can-be-guessed-e
 
 # Politics
 
-https://www.zdnet.com/article/us-rolls-out-new-rules-governing-export-of-hacking-cyberdefense-tools/ 
+https://www.zdnet.com/article/us-rolls-out-new-rules-governing-export-of-hacking-cyberdefense-tools/
 
 https://metro.co.uk/2021/10/17/scotland-facial-recognition-software-being-used-in-north-ayrshire-schools-15437868/
 
-https://www.zdnet.com/article/personal-data-protection-to-become-a-fundamental-right-in-brazil/ 
+https://www.zdnet.com/article/personal-data-protection-to-become-a-fundamental-right-in-brazil/
 
 # FOSS
 


### PR DESCRIPTION
Trailing spaces on hyperlink addresses makes the URL not render correctly. Even better would be to surround the URLs with `<` & `>` to ensure a proper markdown render.